### PR TITLE
Fix unreachable code warning in NVBENCH_MAIN macro

### DIFF
--- a/nvbench/main.cuh
+++ b/nvbench/main.cuh
@@ -87,7 +87,6 @@
   try                                                                                              \
   {                                                                                                \
     NVBENCH_MAIN_BODY(argc, argv);                                                                 \
-    return 0;                                                                                      \
   }                                                                                                \
   NVBENCH_MAIN_CATCH_EXCEPTIONS_CUSTOM                                                             \
   NVBENCH_MAIN_CATCH_EXCEPTIONS


### PR DESCRIPTION
## Summary
- remove redundant `return 0` in `NVBENCH_MAIN` macro to prevent unreachable code warnings

## Testing
- `pre-commit run --files nvbench/main.cuh`
- `cmake -S . -B build -GNinja -DNVBench_ENABLE_TESTING=ON -DCMAKE_CUDA_ARCHITECTURES=80`
- `cmake --build build -j2`
- `cd build && ctest --output-on-failure` *(fails: libnvidia-ml.so.1: cannot open shared object file)*


------
https://chatgpt.com/codex/tasks/task_e_68b7860fe65c832bae527a76adcde89f